### PR TITLE
fix: make eslint packages priority lower

### DIFF
--- a/default.json
+++ b/default.json
@@ -53,6 +53,7 @@
         "eslint"
       ],
       "automerge": true,
+      "prPriority": -1,
       "separateMajorMinor": false
     },
     {


### PR DESCRIPTION
More info about the `prPriority`: https://docs.renovatebot.com/configuration-options/#prpriority