### PR TITLE
fix: fix renovate playwright workflow updates

### DIFF
--- a/default.json
+++ b/default.json
@@ -19,6 +19,18 @@
     "**/bower_components/**",
     "**/vendor/**"
   ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["\\.github/workflows/.*\\.yml$"],
+      "matchStrings": [
+        "playwright_version:\\s*(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)"
+      ],
+      "datasourceTemplate": "npm",
+      "depNameTemplate": "@playwright/test",
+      "versioningTemplate": "semver"
+    }
+  ],
   "packageRules": [
     {
       "matchDepTypes": [
@@ -67,19 +79,9 @@
     },
     {
       "groupName": "Playwright version sync",
-      "packageNames": ["@playwright/test"],
-      "customManagers": [
-        {
-          "customType": "regex",
-          "fileMatch": [".github/workflows/app-health-cd.yml"],
-          "matchStrings": [
-            "playwright_version:\\s(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)"
-          ],
-          "datasourceTemplate": "npm",
-          "depNameTemplate": "@playwright/test",
-          "versioningTemplate": "semver"
-        }
-      ]
+      "groupSlug": "playwright-packages",
+      "matchPackageNames": ["@playwright/test"],
+      "matchManagers": ["npm", "regex"]
     }
   ],
   "postUpdateOptions": ["yarnDedupeHighest"]


### PR DESCRIPTION
Fix Renovate configuration to sync Playwright versions across `package.json` and GitHub Actions workflows.

The previous Renovate configuration failed to update the `playwright_version` in workflow files due to incorrect placement of `customManagers` and an imprecise regex. This PR corrects the `customManagers` location and refines the regex to ensure the Playwright version in `.github/workflows/app-health-cd.yml` is updated in sync with `package.json`.